### PR TITLE
Add placeholder for missing repository

### DIFF
--- a/DUMMY_PR.md
+++ b/DUMMY_PR.md
@@ -1,0 +1,4 @@
+# Dummy Pull Request Placeholder
+
+Attempted to create a dummy pull request for the `hardoff-co-jp/komtar_herbert_member_ios` repository, but the repository is not available in this environment and cloning via HTTPS is blocked (CONNECT tunnel failed with HTTP 403). This placeholder file documents the attempt within the available workspace.
+


### PR DESCRIPTION
## Summary
- add a placeholder file explaining that the requested repository (hardoff-co-jp/komtar_herbert_member_ios) is unavailable in this environment
- document the failed attempt to access the repository so the situation is visible in the repo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5e02082748328a454c86099c3dc52